### PR TITLE
android: Intermittent signature failures due to 0 width/height

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ import injectedExecuteNativeFunction from './injectedJavaScript/executeNativeFun
 class SignaturePad extends Component {
 
   static propTypes = {
+    defaultHeight: PropTypes.number,
+    defaultWidth: PropTypes.number,
     onChange: PropTypes.func,
     onError: PropTypes.func,
     style: View.propTypes.style,
@@ -40,7 +42,7 @@ class SignaturePad extends Component {
     var injectedJavaScript = injectedExecuteNativeFunction
       + injectedErrorHandler
       + injectedSignaturePad
-      + injectedApplication(props.penColor, backgroundColor, props.dataURL);
+      + injectedApplication(props.penColor, backgroundColor, props.dataURL, props.defaultHeight, props.defaultWidth);
     var html = htmlContent(injectedJavaScript);
     this.source = {html}; //We don't use WebView's injectedJavaScript because on Android, the WebView re-injects the JavaScript upon every url change. Given that we use url changes to communicate signature changes to the React Native app, the JS is re-injected every time a stroke is drawn.
   }
@@ -122,6 +124,7 @@ class SignaturePad extends Component {
                  renderError={this._renderError}
                  renderLoading={this._renderLoading}
                  source={this.source}
+                 scrollEnabled={false}
                  javaScriptEnabled={true}
                  style={this.props.style}/>
     )

--- a/injectedHtml/index.js
+++ b/injectedHtml/index.js
@@ -17,6 +17,12 @@ var content = script =>
       -webkit-transform:rotate(-90deg)  translate(-100%, 0px);*/
     }
 
+    html,body {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+    }
+
     </style>
     <body>
       <canvas style="margin-left: 0; margin-top: 0;"></canvas>

--- a/injectedJavaScript/application.js
+++ b/injectedJavaScript/application.js
@@ -1,10 +1,6 @@
-var content = (penColor, backgroundColor, dataURL) => `
+var content = (penColor, backgroundColor, dataURL, defaultHeight, defaultWidth) => `
 
   var showSignaturePad = function (signaturePadCanvas, bodyWidth, bodyHeight) {
-    /*We're rotating by 90% -> Flip X and Y*/
-    /*var width = bodyHeight;
-    var height = bodyWidth;*/
-
     var width = bodyWidth;
     var height = bodyHeight;
 
@@ -48,10 +44,10 @@ var content = (penColor, backgroundColor, dataURL) => `
   var bodyWidth = document.body.clientWidth;
   var bodyHeight = document.body.clientHeight;
   if(!bodyWidth) {
-    bodyWidth = window.innerWidth;
+    bodyWidth = window.innerWidth ? window.innerWidth : ${defaultWidth};
   }
   if(!bodyHeight) {
-    bodyHeight = window.innerHeight;
+    bodyHeight = window.innerHeight ? window.innerHeight : ${defaultHeight};
   }
 
   var canvasElement = document.querySelector('canvas');


### PR DESCRIPTION
Signatures on Android occasionally fail due to document.body.clientWidth
and window.innerWidth (as well as document.body.clientHeight and
window.innerHeight) being 0 on initialization.

I attempted to fix this by adding a setTimeout with a 300ms delay, but
even that was not a 100% effective fix. This issue is most likely
related to:
http://tripleodeon.com/2011/12/first-understand-your-screen/
http://stackoverflow.com/questions/10610743/android-browsers-screen-width-screen-height-window-innerwidth-window-inner

Note that I attempted to apply the ReactNative measured dimensions
instead of using document.body.clientWidth, but that broke iOS.

This fix will not address any rendering issues related to rotating,
since we would need to register a callback and re-initialize the canvas
element on rotation.